### PR TITLE
Stabilize installation, configuration, and file safety

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,10 +1,32 @@
 {
   "mcpServers": {
-    "office-editor": {
+    "office-word": {
       "command": "python",
-      "args": ["path/to/office_server.py"],
+      "args": ["C:/path/to/office-editor-mcp/word_server.py"],
       "env": {
-        "OFFICE_EDIT_PATH": "path/to/output/folder"
+        "OFFICE_EDIT_PATH": "C:/path/to/output/folder"
+      }
+    },
+    "office-excel": {
+      "command": "python",
+      "args": ["C:/path/to/office-editor-mcp/excel_server.py"],
+      "env": {
+        "OFFICE_EDIT_PATH": "C:/path/to/output/folder"
+      }
+    },
+    "office-powerpoint": {
+      "command": "python",
+      "args": ["C:/path/to/office-editor-mcp/powerpoint_server.py"],
+      "env": {
+        "OFFICE_EDIT_PATH": "C:/path/to/output/folder"
+      }
+    },
+    "office-general": {
+      "command": "python",
+      "args": ["C:/path/to/office-editor-mcp/general_server.py"],
+      "env": {
+        "OFFICE_EDIT_PATH": "C:/path/to/output/folder",
+        "OFFICE_ALLOW_DESTRUCTIVE": "false"
       }
     }
   }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+      - name: Compile sources
+        run: python -m compileall -q .
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -v

--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ Office-Editor-MCP implements the [Model Context Protocol](https://modelcontextpr
 ## Installation Guide
 
 ### Prerequisites
-- Python 3.7 or higher
+- Python 3.10 or higher
 - pip package manager
-- Microsoft Office or compatible components (such as python-docx, openpyxl)
+- Microsoft Office is only required for Windows COM features such as PDF export,
+  animations, transitions, and legacy Office formats
+- Tesseract OCR is required when using `ocr_recognize_text`
 
 ### Basic Installation
 
@@ -89,6 +91,11 @@ cd office-editor-mcp
 # Install dependencies
 pip install -r requirements.txt
 ```
+
+The repository exposes four independent MCP servers: `word_server.py`,
+`excel_server.py`, `powerpoint_server.py`, and `general_server.py`. Configure
+only the servers you need. The checked-in `.cursor/mcp.json` contains a complete
+four-server example.
 
 ## Configuration
 
@@ -104,7 +111,7 @@ pip install -r requirements.txt
    - Type: Select `stdio`
    - Command: Enter the full path to run the server, for example:
      ```
-     python /path/to/office_server.py
+     python /path/to/office-editor-mcp/word_server.py
      ```
      Note: Replace with your actual file path
 
@@ -118,8 +125,8 @@ pip install -r requirements.txt
   "mcpServers": {
     "office-assistant": {
       "command": "python",
-      "args": ["/path/to/office_server.py"],
-      "env": {}
+      "args": ["/path/to/office-editor-mcp/word_server.py"],
+      "env": {"OFFICE_EDIT_PATH": "/path/to/output"}
     }
   }
 }
@@ -139,7 +146,7 @@ pip install -r requirements.txt
     "office-document-server": {
       "command": "python",
       "args": [
-        "/path/to/office_server.py"
+        "/path/to/office-editor-mcp/word_server.py"
       ]
     }
   }
@@ -147,6 +154,10 @@ pip install -r requirements.txt
 ```
 
 3. Restart Claude to apply the configuration.
+
+All paths handled by `general_server.py` must stay inside `OFFICE_EDIT_PATH`.
+Move and delete operations are disabled unless
+`OFFICE_ALLOW_DESTRUCTIVE=true` is explicitly configured.
 
 ## Usage Examples
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -75,9 +75,10 @@ Office-Editor-MCP实现了[Model Context Protocol](https://modelcontextprotocol.
 ## 安装指南
 
 ### 前提条件
-- Python 3.7 或更高版本
+- Python 3.10 或更高版本
 - pip 包管理器
-- Microsoft Office或兼容组件（如python-docx, openpyxl）
+- 仅 PDF 导出、动画、转场和旧版 Office 格式等 Windows COM 功能需要安装 Microsoft Office
+- 使用 `ocr_recognize_text` 时需要另行安装 Tesseract OCR
 
 ### 基本安装
 
@@ -89,6 +90,10 @@ cd office-editor-mcp
 # 安装依赖
 pip install -r requirements.txt
 ```
+
+仓库提供四个独立的 MCP 服务器：`word_server.py`、`excel_server.py`、
+`powerpoint_server.py` 和 `general_server.py`。可以只配置需要的服务器；仓库中的
+`.cursor/mcp.json` 提供了完整的四服务器配置示例。
 
 ## 配置说明
 
@@ -104,7 +109,7 @@ pip install -r requirements.txt
    - 类型：选择`stdio`
    - 命令：输入运行服务器的完整路径，例如：
      ```
-     python /path/to/office_server.py
+     python /path/to/office-editor-mcp/word_server.py
      ```
      注意替换为您实际的文件路径
 
@@ -118,8 +123,8 @@ pip install -r requirements.txt
   "mcpServers": {
     "office-assistant": {
       "command": "python",
-      "args": ["/path/to/office_server.py"],
-      "env": {}
+      "args": ["/path/to/office-editor-mcp/word_server.py"],
+      "env": {"OFFICE_EDIT_PATH": "/path/to/output"}
     }
   }
 }
@@ -139,7 +144,7 @@ pip install -r requirements.txt
     "office-document-server": {
       "command": "python",
       "args": [
-        "/path/to/office_server.py"
+        "/path/to/office-editor-mcp/word_server.py"
       ]
     }
   }
@@ -147,6 +152,9 @@ pip install -r requirements.txt
 ```
 
 3. 重启Claude使配置生效。
+
+`general_server.py` 处理的所有路径都必须位于 `OFFICE_EDIT_PATH` 内。移动和删除操作
+默认禁用，只有显式配置 `OFFICE_ALLOW_DESTRUCTIVE=true` 后才会开放。
 
 ## 使用示例
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,11 +4,10 @@
 
 本项目需要以下依赖：
 
-1. Python 3.7或更高版本
-2. MCP SDK
-3. python-docx库（用于Word文档操作）
-4. Pillow库（用于图像处理）
-5. pywin32（可选，Windows系统用于增强功能）
+1. Python 3.10或更高版本
+2. MCP SDK和Office文档处理依赖（由`requirements.txt`统一安装）
+3. Microsoft Office（仅Windows COM增强功能需要）
+4. Tesseract OCR（仅OCR功能需要）
 
 ### 使用pip安装
 
@@ -18,10 +17,15 @@ pip install -r requirements.txt
 
 ## 2. 服务器配置
 
-项目提供了两个主要的服务器实现：
+项目提供四个独立的服务器实现：
 
-1. `create_txt_server.py` - 简单文本文件创建服务器（仅用于功能测试）
-2. `office_server.py` - 完整的Office文档处理服务器（需要下载完整项目）
+1. `word_server.py` - Word文档操作
+2. `excel_server.py` - Excel工作簿操作
+3. `powerpoint_server.py` - PowerPoint演示文稿操作
+4. `general_server.py` - OCR、比较、翻译、加密和批处理等通用功能
+
+仓库中没有`office_server.py`。客户端可以只配置需要的服务器，也可以参考
+`.cursor/mcp.json`一次配置全部四个服务器。
 
 ## 3. 在Cursor中配置
 
@@ -35,7 +39,7 @@ pip install -r requirements.txt
    - 类型：选择`stdio`
    - 命令：输入运行服务器的完整路径，例如：
      ```
-     python C:/path/to/office_server.py
+     python C:/path/to/office-editor-mcp/word_server.py
      ```
 
 ### 方法二：通过配置文件配置（推荐）
@@ -46,9 +50,9 @@ pip install -r requirements.txt
 ```json
 {
   "mcpServers": {
-    "office-editor": {
+    "office-word": {
       "command": "python",
-      "args": ["C:/path/to/office_server.py"],
+      "args": ["C:/path/to/office-editor-mcp/word_server.py"],
       "env": {
         "OFFICE_EDIT_PATH": "C:/path/to/output/folder"
       }
@@ -57,25 +61,20 @@ pip install -r requirements.txt
 }
 ```
 
-请替换路径为您实际的文件路径。`OFFICE_EDIT_PATH`环境变量指定文档的默认保存位置，如不设置则默认为桌面。
+请替换路径为实际的绝对路径。`OFFICE_EDIT_PATH`指定文档工作目录。通用服务器只允许
+访问该目录内的路径；移动和删除默认禁用，只有显式设置
+`OFFICE_ALLOW_DESTRUCTIVE=true`后才会开放。
 
 3. 重启Cursor使配置生效。
 
 ## 4. 功能测试
 
-项目包含一个测试脚本 `test_server.py`，它可以：
-
-1. 检查MCP SDK是否正确安装
-2. 验证服务器脚本是否存在
-3. 尝试启动服务器并测试基本功能
-
-运行测试脚本：
+运行静态编译和安全边界测试：
 
 ```bash
-python test_server.py
+python -m compileall -q .
+python -m unittest discover -s tests -v
 ```
-
-如果测试通过，您会看到一系列成功消息，表明服务器已正确配置。
 
 ## 5. 使用示例
 

--- a/general_server.py
+++ b/general_server.py
@@ -13,6 +13,12 @@ import logging
 import time
 import base64
 import io
+import concurrent.futures
+import difflib
+import hashlib
+import shutil
+import threading
+from pathlib import Path
 from mcp.server.fastmcp import FastMCP
 from typing import Dict, Any, List, Union, Tuple
 
@@ -38,29 +44,53 @@ try:
     import PyPDF2
     import pytesseract
     from PIL import Image
-    import difflib
     import deepl
     import cryptography
     from cryptography.fernet import Fernet
     import sqlalchemy
     from sqlalchemy import create_engine, text, MetaData, Table, Column, inspect
-    import threading
-    import concurrent.futures
     import pandas as pd
-    import shutil
-    import hashlib
 except ImportError as e:
     logger.error(f"导入错误: {e}")
-    logger.info("请安装所需依赖: pip install python-docx openpyxl python-pptx pdf2docx PyPDF2 pytesseract Pillow difflib deepl cryptography sqlalchemy pandas")
+    logger.info("请使用 pip install -r requirements.txt 安装所需依赖")
 
 # 全局变量
-OUTPUT_DIR = os.environ.get("OFFICE_EDIT_PATH", os.path.expanduser("~"))
+OUTPUT_DIR = os.environ.get(
+    "OFFICE_EDIT_PATH", os.path.join(os.path.expanduser("~"), "office-editor-output")
+)
 logger.info(f"输出目录设置为: {OUTPUT_DIR}")
 
 # 创建一个MCP服务器
 mcp = FastMCP("office-editor")
 
 # 工具函数
+def _workspace_root() -> Path:
+    """Return the configured workspace as an absolute, normalized path."""
+    return Path(OUTPUT_DIR).expanduser().resolve()
+
+
+def _resolve_workspace_path(file_path: str) -> str:
+    """Resolve a path and reject access outside OFFICE_EDIT_PATH."""
+    root = _workspace_root()
+    candidate = Path(file_path).expanduser()
+    if not candidate.is_absolute():
+        candidate = root / candidate
+
+    resolved = candidate.resolve(strict=False)
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"路径必须位于 OFFICE_EDIT_PATH 内: {file_path}") from exc
+    return str(resolved)
+
+
+def _destructive_operations_enabled() -> bool:
+    """Destructive file operations require an explicit opt-in."""
+    return os.environ.get("OFFICE_ALLOW_DESTRUCTIVE", "").lower() in {
+        "1", "true", "yes", "on"
+    }
+
+
 def extract_document_text(doc_path: str) -> str:
     """从不同类型的文档中提取文本内容"""
     ext = os.path.splitext(doc_path)[1].lower()
@@ -738,14 +768,15 @@ def batch_process_documents(files: List[str], operation: str, params: Dict[str, 
 
 # 文件目录操作功能
 @mcp.tool()
-def general_file_operations(operation: str, source_path: str, 
+def general_file_operations(operation: str, source_path: str,
                          target_path: str = None, recursive: bool = False) -> Dict[str, Any]:
     """
     通用文件和目录操作
     
     Args:
-        operation: 操作类型，"copy"复制, "move"移动, "delete"删除, "list"列表
-        source_path: 源文件或目录路径
+        operation: 操作类型，"copy"复制, "move"移动, "delete"删除, "list"列表。
+                   move/delete 需要设置 OFFICE_ALLOW_DESTRUCTIVE=true
+        source_path: OFFICE_EDIT_PATH 内的源文件或目录路径
         target_path: 目标路径，用于复制和移动操作
         recursive: 是否递归处理子目录
         
@@ -753,6 +784,20 @@ def general_file_operations(operation: str, source_path: str,
         包含操作结果的字典
     """
     try:
+        operation = operation.lower()
+        source_path = _resolve_workspace_path(source_path)
+        if target_path is not None:
+            target_path = _resolve_workspace_path(target_path)
+
+        if operation in {"move", "delete"} and not _destructive_operations_enabled():
+            return {
+                "success": False,
+                "message": (
+                    f"{operation} 操作默认禁用；如确有需要，请显式设置 "
+                    "OFFICE_ALLOW_DESTRUCTIVE=true"
+                ),
+            }
+
         # 检查源路径是否存在
         if not os.path.exists(source_path):
             return {"success": False, "message": f"源路径不存在: {source_path}"}

--- a/powerpoint_server.py
+++ b/powerpoint_server.py
@@ -1207,7 +1207,7 @@ def insert_chart(file_path: str, slide_index: int, chart_type: str, data: List[L
         return f"错误: 文件 {file_path} 不存在"
     
     # 验证图表类型
-    from pptx.enum.charts import XL_CHART_TYPE
+    from pptx.enum.chart import XL_CHART_TYPE
     chart_type_map = {
         "column": XL_CHART_TYPE.COLUMN_CLUSTERED,
         "line": XL_CHART_TYPE.LINE,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,15 @@
-mcp>=0.1.4
-python-docx>=0.8.11
-Pillow>=9.0.0
-# 以下依赖在Windows系统上可选
-# pywin32>=305
+mcp>=1.27,<2
+python-docx>=1.1,<2
+openpyxl>=3.1,<4
+python-pptx>=1.0,<2
+Pillow>=10,<13
+pandas>=2,<4
+numpy>=1.26,<3
+pdf2docx>=0.5,<1
+PyPDF2>=3,<4
+pytesseract>=0.3,<1
+deepl>=1.18,<2
+cryptography>=42,<47
+SQLAlchemy>=2,<3
+xlwt>=1.3,<2
+pywin32>=306; sys_platform == "win32"

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,31 @@
+import json
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ConfigurationTests(unittest.TestCase):
+    def test_cursor_configuration_references_existing_servers(self):
+        config = json.loads((REPOSITORY_ROOT / ".cursor" / "mcp.json").read_text())
+        servers = config["mcpServers"]
+        self.assertEqual(
+            set(servers),
+            {"office-word", "office-excel", "office-powerpoint", "office-general"},
+        )
+
+        for server in servers.values():
+            script_name = Path(server["args"][0]).name
+            self.assertTrue((REPOSITORY_ROOT / script_name).is_file(), script_name)
+
+    def test_documentation_does_not_reference_missing_entrypoint(self):
+        documentation = "\n".join(
+            (REPOSITORY_ROOT / name).read_text(encoding="utf-8")
+            for name in ("README.md", "README_CN.md", "docs/INSTALL.md")
+        )
+        self.assertNotIn("/office_server.py", documentation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_general_file_security.py
+++ b/tests/test_general_file_security.py
@@ -1,0 +1,54 @@
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import general_server
+
+
+class WorkspacePathTests(unittest.TestCase):
+    def setUp(self):
+        self.original_output_dir = general_server.OUTPUT_DIR
+        general_server.OUTPUT_DIR = str(Path.cwd() / "test-output")
+
+    def tearDown(self):
+        general_server.OUTPUT_DIR = self.original_output_dir
+
+    def test_relative_path_is_resolved_inside_workspace(self):
+        resolved = Path(general_server._resolve_workspace_path("reports/test.docx"))
+        self.assertEqual(
+            resolved,
+            (Path.cwd() / "test-output" / "reports" / "test.docx").resolve(),
+        )
+
+    def test_parent_traversal_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "OFFICE_EDIT_PATH"):
+            general_server._resolve_workspace_path("../outside.txt")
+
+    def test_absolute_path_outside_workspace_is_rejected(self):
+        outside = Path.cwd().parent / "outside.txt"
+        with self.assertRaisesRegex(ValueError, "OFFICE_EDIT_PATH"):
+            general_server._resolve_workspace_path(str(outside))
+
+
+class DestructiveOperationTests(unittest.TestCase):
+    def setUp(self):
+        self.original_output_dir = general_server.OUTPUT_DIR
+        general_server.OUTPUT_DIR = str(Path.cwd())
+
+    def tearDown(self):
+        general_server.OUTPUT_DIR = self.original_output_dir
+
+    @patch.dict(os.environ, {}, clear=False)
+    @patch("general_server.os.path.exists", return_value=True)
+    @patch("general_server.os.remove")
+    def test_delete_is_disabled_by_default(self, remove_mock, _exists_mock):
+        os.environ.pop("OFFICE_ALLOW_DESTRUCTIVE", None)
+        result = general_server.general_file_operations("delete", "protected.txt")
+        self.assertFalse(result["success"])
+        self.assertIn("OFFICE_ALLOW_DESTRUCTIVE", result["message"])
+        remove_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- replace references to the missing `office_server.py` entrypoint with working per-application server configuration
- align the documented Python baseline and install all dependencies used by the advertised features
- fix the `python-pptx` chart enum import reported in issue #4
- restrict general file operations to `OFFICE_EDIT_PATH`
- keep move and delete operations disabled unless `OFFICE_ALLOW_DESTRUCTIVE=true` is explicitly configured
- add Windows CI plus configuration and path-safety tests

## Why

The basic installation did not install the dependencies required by the Excel, PowerPoint, and general servers, while the setup documentation pointed users at a file that does not exist. The general file tool also accepted unrestricted paths and enabled destructive operations by default.

## Impact

Existing document tools keep their current entrypoints. Users now configure the four real server scripts directly. `general_server.py` defaults to `~/office-editor-output`, rejects paths outside the configured workspace, and requires an explicit opt-in for move/delete operations.

## Validation

- `python -m compileall -q .`
- `python -m unittest discover -s tests -v` (6 tests passed)
- Python AST parsing for all server modules
- JSON parsing for `.cursor/mcp.json`
- staged diff whitespace check