### PR TITLE
Harden general operations and MCP stdio

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ All paths handled by `general_server.py` must stay inside `OFFICE_EDIT_PATH`.
 Move and delete operations are disabled unless
 `OFFICE_ALLOW_DESTRUCTIVE=true` is explicitly configured.
 
+New encrypted files use a versioned Fernet container with a random salt and
+Scrypt password derivation. Existing encrypted files remain readable and can be
+re-encrypted to upgrade them. Batch operations are limited to 100 files and 16
+workers per request.
+
 ## Usage Examples
 
 After configuration, you can issue commands to your AI assistant like:

--- a/README_CN.md
+++ b/README_CN.md
@@ -156,6 +156,9 @@ pip install -r requirements.txt
 `general_server.py` 处理的所有路径都必须位于 `OFFICE_EDIT_PATH` 内。移动和删除操作
 默认禁用，只有显式配置 `OFFICE_ALLOW_DESTRUCTIVE=true` 后才会开放。
 
+新加密文件使用带随机盐和 Scrypt 密钥派生的版本化 Fernet 容器；旧版加密文件仍可
+读取，并可通过重新加密完成升级。每次批处理最多接受100个文件和16个工作线程。
+
 ## 使用示例
 
 配置完成后，您可以向AI助手发出如下指令：

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -65,6 +65,9 @@ pip install -r requirements.txt
 访问该目录内的路径；移动和删除默认禁用，只有显式设置
 `OFFICE_ALLOW_DESTRUCTIVE=true`后才会开放。
 
+新加密文件使用随机盐和Scrypt密钥派生；旧版加密文件仍可读取。批处理请求最多处理
+100个文件，并限制为最多16个工作线程。
+
 3. 重启Cursor使配置生效。
 
 ## 4. 功能测试

--- a/excel_server.py
+++ b/excel_server.py
@@ -22,8 +22,8 @@ try:
     from openpyxl.styles.colors import Color
     from openpyxl.utils import get_column_letter, column_index_from_string
 except ImportError:
-    print("警告: 未检测到openpyxl库，Excel功能将不可用")
-    print("请使用以下命令安装: pip install openpyxl")
+    print("警告: 未检测到openpyxl库，Excel功能将不可用", file=sys.stderr)
+    print("请使用以下命令安装: pip install openpyxl", file=sys.stderr)
     openpyxl_installed = False
 
 # 尝试导入Pandas库，用于数据处理
@@ -32,8 +32,8 @@ try:
     import pandas as pd
     import numpy as np
 except ImportError:
-    print("警告: 未检测到pandas库，高级数据处理功能将受限")
-    print("请使用以下命令安装: pip install pandas numpy")
+    print("警告: 未检测到pandas库，高级数据处理功能将受限", file=sys.stderr)
+    print("请使用以下命令安装: pip install pandas numpy", file=sys.stderr)
     pandas_installed = False
 
 # 创建一个MCP服务器，保持名称与配置文件一致
@@ -3449,5 +3449,5 @@ def apply_if(
 
 if __name__ == "__main__":
     # 运行MCP服务器
-    print("启动Excel MCP服务器...")
+    print("启动Excel MCP服务器...", file=sys.stderr)
     mcp.run()

--- a/general_server.py
+++ b/general_server.py
@@ -31,28 +31,72 @@ logging.basicConfig(
 
 logger = logging.getLogger("GeneralServer")
 
-# 导入Office操作相关库
+# 独立加载可选依赖，避免一个缺失包禁用所有通用工具。
+def _optional_import_failed(feature: str, error: ImportError) -> None:
+    logger.warning("%s 功能依赖不可用: %s", feature, error)
+
+
 try:
     import docx
     from docx.shared import Pt, RGBColor, Inches
+except ImportError as error:
+    _optional_import_failed("Word", error)
+
+try:
     import openpyxl
     from openpyxl.utils import get_column_letter
     from openpyxl.styles import Font, PatternFill, Alignment
+except ImportError as error:
+    _optional_import_failed("Excel", error)
+
+try:
     from pptx import Presentation
     from pptx.util import Inches as PptxInches
+except ImportError as error:
+    _optional_import_failed("PowerPoint", error)
+
+try:
     import pdf2docx
+except ImportError as error:
+    _optional_import_failed("PDF转换", error)
+
+try:
     import PyPDF2
+except ImportError as error:
+    _optional_import_failed("PDF读取", error)
+
+try:
     import pytesseract
+except ImportError as error:
+    _optional_import_failed("OCR", error)
+
+try:
     from PIL import Image
+except ImportError as error:
+    _optional_import_failed("图片处理", error)
+
+try:
     import deepl
+except ImportError as error:
+    _optional_import_failed("翻译", error)
+
+try:
     import cryptography
     from cryptography.fernet import Fernet
+    from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
+except ImportError as error:
+    _optional_import_failed("加密", error)
+
+try:
     import sqlalchemy
     from sqlalchemy import create_engine, text, MetaData, Table, Column, inspect
+except ImportError as error:
+    _optional_import_failed("数据库", error)
+
+try:
     import pandas as pd
-except ImportError as e:
-    logger.error(f"导入错误: {e}")
-    logger.info("请使用 pip install -r requirements.txt 安装所需依赖")
+except ImportError as error:
+    _optional_import_failed("数据处理", error)
 
 # 全局变量
 OUTPUT_DIR = os.environ.get(
@@ -84,6 +128,13 @@ def _resolve_workspace_path(file_path: str) -> str:
     return str(resolved)
 
 
+def _prepare_output_path(file_path: str) -> str:
+    """Resolve an output path inside the workspace and create its parent."""
+    resolved = Path(_resolve_workspace_path(file_path))
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    return str(resolved)
+
+
 def _destructive_operations_enabled() -> bool:
     """Destructive file operations require an explicit opt-in."""
     return os.environ.get("OFFICE_ALLOW_DESTRUCTIVE", "").lower() in {
@@ -91,8 +142,47 @@ def _destructive_operations_enabled() -> bool:
     }
 
 
+ENCRYPTION_MAGIC = b"OEMCP\x01"
+ENCRYPTION_SALT_SIZE = 16
+MAX_BATCH_FILES = 100
+MAX_BATCH_WORKERS = 16
+
+
+def _derive_encryption_key(password: str, salt: bytes) -> bytes:
+    """Derive a Fernet key using a salted, intentionally expensive KDF."""
+    if not password:
+        raise ValueError("密码不能为空")
+    kdf = Scrypt(salt=salt, length=32, n=2**14, r=8, p=1)
+    return base64.urlsafe_b64encode(kdf.derive(password.encode("utf-8")))
+
+
+def _encrypt_payload(data: bytes, password: str) -> bytes:
+    salt = os.urandom(ENCRYPTION_SALT_SIZE)
+    token = Fernet(_derive_encryption_key(password, salt)).encrypt(data)
+    return ENCRYPTION_MAGIC + salt + token
+
+
+def _decrypt_payload(payload: bytes, password: str) -> Tuple[bytes, bool]:
+    """Decrypt current containers and legacy unsalted Fernet payloads."""
+    if payload.startswith(ENCRYPTION_MAGIC):
+        header_size = len(ENCRYPTION_MAGIC) + ENCRYPTION_SALT_SIZE
+        if len(payload) <= header_size:
+            raise ValueError("加密文件格式无效")
+        salt = payload[len(ENCRYPTION_MAGIC):header_size]
+        token = payload[header_size:]
+        key = _derive_encryption_key(password, salt)
+        return Fernet(key).decrypt(token), False
+
+    # Backward compatibility for files created before the versioned container.
+    legacy_key = base64.urlsafe_b64encode(
+        hashlib.sha256(password.encode("utf-8")).digest()
+    )
+    return Fernet(legacy_key).decrypt(payload), True
+
+
 def extract_document_text(doc_path: str) -> str:
     """从不同类型的文档中提取文本内容"""
+    doc_path = _resolve_workspace_path(doc_path)
     ext = os.path.splitext(doc_path)[1].lower()
     
     try:
@@ -148,6 +238,7 @@ def extract_document_text(doc_path: str) -> str:
 
 def replace_placeholders(file_path: str, data_mapping: Dict[str, List[str]], index: int):
     """替换文档中的占位符"""
+    file_path = _resolve_workspace_path(file_path)
     ext = os.path.splitext(file_path)[1].lower()
     
     try:
@@ -227,6 +318,8 @@ def ocr_recognize_text(image_path: str, language: str = "chi_sim+eng") -> Dict[s
         if 'pytesseract' not in sys.modules:
             return {"success": False, "message": "缺少必要依赖: pytesseract"}
         
+        image_path = _resolve_workspace_path(image_path)
+
         # 检查图片文件是否存在
         if not os.path.exists(image_path):
             return {"success": False, "message": f"图片文件不存在: {image_path}"}
@@ -243,7 +336,9 @@ def ocr_recognize_text(image_path: str, language: str = "chi_sim+eng") -> Dict[s
         end_time = time.time()
         
         # 保存识别结果到txt文件
-        output_file = os.path.join(OUTPUT_DIR, os.path.splitext(os.path.basename(image_path))[0] + "_ocr.txt")
+        output_file = _prepare_output_path(
+            os.path.splitext(os.path.basename(image_path))[0] + "_ocr.txt"
+        )
         with open(output_file, "w", encoding="utf-8") as f:
             f.write(text)
         
@@ -273,6 +368,9 @@ def compare_documents(doc1_path: str, doc2_path: str, output_format: str = "html
         包含比较结果的字典
     """
     try:
+        doc1_path = _resolve_workspace_path(doc1_path)
+        doc2_path = _resolve_workspace_path(doc2_path)
+
         # 检查文件是否存在
         if not os.path.exists(doc1_path):
             return {"success": False, "message": f"文件不存在: {doc1_path}"}
@@ -298,13 +396,13 @@ def compare_documents(doc1_path: str, doc2_path: str, output_format: str = "html
         if output_format == 'html':
             diff = difflib.HtmlDiff()
             result = diff.make_file(lines1, lines2, os.path.basename(doc1_path), os.path.basename(doc2_path))
-            output_file = os.path.join(OUTPUT_DIR, "document_diff.html")
+            output_file = _prepare_output_path("document_diff.html")
             with open(output_file, "w", encoding="utf-8") as f:
                 f.write(result)
         else:  # text format
             diff = difflib.unified_diff(lines1, lines2, os.path.basename(doc1_path), os.path.basename(doc2_path))
             result = '\n'.join(list(diff))
-            output_file = os.path.join(OUTPUT_DIR, "document_diff.txt")
+            output_file = _prepare_output_path("document_diff.txt")
             with open(output_file, "w", encoding="utf-8") as f:
                 f.write(result)
         
@@ -338,6 +436,8 @@ def translate_document(doc_path: str, target_language: str = "ZH", api_key: str 
         if 'deepl' not in sys.modules:
             return {"success": False, "message": "缺少必要依赖: deepl"}
         
+        doc_path = _resolve_workspace_path(doc_path)
+
         # 检查文件是否存在
         if not os.path.exists(doc_path):
             return {"success": False, "message": f"文件不存在: {doc_path}"}
@@ -366,7 +466,9 @@ def translate_document(doc_path: str, target_language: str = "ZH", api_key: str 
         
         # 保存翻译结果
         filename = os.path.splitext(os.path.basename(doc_path))[0]
-        output_file = os.path.join(OUTPUT_DIR, f"{filename}_translated_{target_language}.txt")
+        output_file = _prepare_output_path(
+            f"{filename}_translated_{target_language}.txt"
+        )
         with open(output_file, "w", encoding="utf-8") as f:
             f.write(translated_text)
         
@@ -400,6 +502,8 @@ def encrypt_document(doc_path: str, password: str) -> Dict[str, Any]:
         if 'cryptography' not in sys.modules:
             return {"success": False, "message": "缺少必要依赖: cryptography"}
         
+        doc_path = _resolve_workspace_path(doc_path)
+
         # 检查文件是否存在
         if not os.path.exists(doc_path):
             return {"success": False, "message": f"文件不存在: {doc_path}"}
@@ -408,17 +512,12 @@ def encrypt_document(doc_path: str, password: str) -> Dict[str, Any]:
         with open(doc_path, 'rb') as file:
             file_data = file.read()
         
-        # 生成密钥
-        password_bytes = password.encode('utf-8')
-        key = base64.urlsafe_b64encode(hashlib.sha256(password_bytes).digest())
-        
-        # 使用Fernet对称加密
-        fernet = Fernet(key)
-        encrypted_data = fernet.encrypt(file_data)
+        # 使用带随机盐的Scrypt派生密钥，并写入带版本的加密容器
+        encrypted_data = _encrypt_payload(file_data, password)
         
         # 保存加密文件
         filename = os.path.splitext(os.path.basename(doc_path))[0]
-        output_file = os.path.join(OUTPUT_DIR, f"{filename}_encrypted.bin")
+        output_file = _prepare_output_path(f"{filename}_encrypted.bin")
         with open(output_file, 'wb') as file:
             file.write(encrypted_data)
         
@@ -451,6 +550,8 @@ def decrypt_document(encrypted_file_path: str, password: str, output_format: str
         if 'cryptography' not in sys.modules:
             return {"success": False, "message": "缺少必要依赖: cryptography"}
         
+        encrypted_file_path = _resolve_workspace_path(encrypted_file_path)
+
         # 检查文件是否存在
         if not os.path.exists(encrypted_file_path):
             return {"success": False, "message": f"文件不存在: {encrypted_file_path}"}
@@ -459,14 +560,11 @@ def decrypt_document(encrypted_file_path: str, password: str, output_format: str
         with open(encrypted_file_path, 'rb') as file:
             encrypted_data = file.read()
         
-        # 生成密钥
-        password_bytes = password.encode('utf-8')
-        key = base64.urlsafe_b64encode(hashlib.sha256(password_bytes).digest())
-        
         # 解密数据
         try:
-            fernet = Fernet(key)
-            decrypted_data = fernet.decrypt(encrypted_data)
+            decrypted_data, used_legacy_format = _decrypt_payload(
+                encrypted_data, password
+            )
         except Exception as e:
             return {"success": False, "message": f"解密失败，密码可能不正确: {str(e)}"}
         
@@ -479,13 +577,16 @@ def decrypt_document(encrypted_file_path: str, password: str, output_format: str
         if filename.endswith("_encrypted"):
             filename = filename[:-10]  # 移除"_encrypted"后缀
             
-        output_file = os.path.join(OUTPUT_DIR, f"{filename}_decrypted{output_ext}")
+        output_file = _prepare_output_path(f"{filename}_decrypted{output_ext}")
         with open(output_file, 'wb') as file:
             file.write(decrypted_data)
         
         return {
             "success": True,
-            "message": "文档解密完成",
+            "message": (
+                "文档解密完成（已兼容读取旧版加密格式，建议重新加密）"
+                if used_legacy_format else "文档解密完成"
+            ),
             "output_file": output_file
         }
         
@@ -515,6 +616,8 @@ def export_excel_to_database(excel_file: str, db_connection_string: str, table_n
         if 'pandas' not in sys.modules or 'sqlalchemy' not in sys.modules:
             return {"success": False, "message": "缺少必要依赖: pandas 或 sqlalchemy"}
         
+        excel_file = _resolve_workspace_path(excel_file)
+
         # 检查文件是否存在
         if not os.path.exists(excel_file):
             return {"success": False, "message": f"文件不存在: {excel_file}"}
@@ -573,10 +676,7 @@ def import_database_to_excel(db_connection_string: str, query: str, output_file:
         df = pd.read_sql(query, engine)
         
         # 设置输出文件名
-        if not output_file:
-            output_file = os.path.join(OUTPUT_DIR, "query_result.xlsx")
-        elif not os.path.isabs(output_file):
-            output_file = os.path.join(OUTPUT_DIR, output_file)
+        output_file = _prepare_output_path(output_file or "query_result.xlsx")
             
         # 导出数据到Excel
         df.to_excel(output_file, index=False)
@@ -615,6 +715,14 @@ def batch_create_documents(template_path: str, output_prefix: str, count: int,
         包含操作结果的字典
     """
     try:
+        if count < 1 or count > MAX_BATCH_FILES:
+            return {
+                "success": False,
+                "message": f"生成数量必须在1到{MAX_BATCH_FILES}之间",
+            }
+
+        template_path = _resolve_workspace_path(template_path)
+
         # 检查模板文件是否存在
         if not os.path.exists(template_path):
             return {"success": False, "message": f"模板文件不存在: {template_path}"}
@@ -629,8 +737,7 @@ def batch_create_documents(template_path: str, output_prefix: str, count: int,
         _, ext = os.path.splitext(template_path)
         
         # 创建输出目录
-        if not os.path.exists(OUTPUT_DIR):
-            os.makedirs(OUTPUT_DIR)
+        _workspace_root().mkdir(parents=True, exist_ok=True)
         
         # 批量生成文档
         start_time = time.time()
@@ -638,7 +745,7 @@ def batch_create_documents(template_path: str, output_prefix: str, count: int,
         
         for i in range(count):
             # 创建输出文件路径
-            output_file = os.path.join(OUTPUT_DIR, f"{output_prefix}_{i+1}{ext}")
+            output_file = _prepare_output_path(f"{output_prefix}_{i+1}{ext}")
             
             # 复制模板文件
             shutil.copy2(template_path, output_file)
@@ -685,7 +792,6 @@ def batch_process_documents(files: List[str], operation: str, params: Dict[str, 
             "ocr_recognize_text": ocr_recognize_text,
             "compare_documents": compare_documents,
             "export_excel_to_database": export_excel_to_database,
-            "import_database_to_excel": import_database_to_excel,
             "general_file_operations": general_file_operations
         }
         
@@ -697,6 +803,17 @@ def batch_process_documents(files: List[str], operation: str, params: Dict[str, 
         op_func = operations_mapping[operation]
         if params is None:
             params = {}
+
+        if not files or len(files) > MAX_BATCH_FILES:
+            return {
+                "success": False,
+                "message": f"文件数量必须在1到{MAX_BATCH_FILES}之间",
+            }
+        if max_workers < 1 or max_workers > MAX_BATCH_WORKERS:
+            return {
+                "success": False,
+                "message": f"max_workers必须在1到{MAX_BATCH_WORKERS}之间",
+            }
         
         # 初始化结果列表
         results = []
@@ -715,7 +832,9 @@ def batch_process_documents(files: List[str], operation: str, params: Dict[str, 
                     "encrypt_document": "doc_path",
                     "decrypt_document": "encrypted_file_path",
                     "ocr_recognize_text": "image_path",
-                    "compare_documents": "doc1_path"  # 注意: 这种情况可能需要特殊处理
+                    "compare_documents": "doc1_path",
+                    "export_excel_to_database": "excel_file",
+                    "general_file_operations": "source_path",
                 }
                 
                 param_name = param_name_mapping.get(operation, "file_path")

--- a/powerpoint_server.py
+++ b/powerpoint_server.py
@@ -24,8 +24,8 @@ try:
     from pptx.enum.shapes import MSO_SHAPE
     from pptx.enum.dml import MSO_THEME_COLOR
 except ImportError:
-    print("警告: 未检测到python-pptx库，PowerPoint功能将不可用")
-    print("请使用以下命令安装: pip install python-pptx")
+    print("警告: 未检测到python-pptx库，PowerPoint功能将不可用", file=sys.stderr)
+    print("请使用以下命令安装: pip install python-pptx", file=sys.stderr)
     pptx_installed = False
 
 # 尝试导入Pillow库，用于图片处理
@@ -33,8 +33,8 @@ pillow_installed = True
 try:
     from PIL import Image
 except ImportError:
-    print("警告: 未检测到Pillow库，图片处理功能将受限")
-    print("请使用以下命令安装: pip install Pillow")
+    print("警告: 未检测到Pillow库，图片处理功能将受限", file=sys.stderr)
+    print("请使用以下命令安装: pip install Pillow", file=sys.stderr)
     pillow_installed = False
 
 # 创建一个MCP服务器，保持名称与配置文件一致
@@ -1701,8 +1701,8 @@ if __name__ == "__main__":
         mcp.run()
     except KeyboardInterrupt:
         # 优雅地处理Ctrl+C中断
-        print("服务器已停止")
+        print("服务器已停止", file=sys.stderr)
     except Exception as e:
         # 处理其他异常
-        print(f"服务器运行时出错: {str(e)}")
+        print(f"服务器运行时出错: {str(e)}", file=sys.stderr)
         sys.exit(1)

--- a/tests/test_batch_limits.py
+++ b/tests/test_batch_limits.py
@@ -1,0 +1,28 @@
+import unittest
+
+import general_server
+
+
+class BatchLimitTests(unittest.TestCase):
+    def test_document_count_is_bounded_before_file_access(self):
+        result = general_server.batch_create_documents("missing.docx", "output", 101)
+        self.assertFalse(result["success"])
+        self.assertIn("1到100", result["message"])
+
+    def test_batch_file_count_is_bounded(self):
+        result = general_server.batch_process_documents(
+            ["file.txt"] * 101, "encrypt_document"
+        )
+        self.assertFalse(result["success"])
+        self.assertIn("1到100", result["message"])
+
+    def test_worker_count_is_bounded(self):
+        result = general_server.batch_process_documents(
+            ["file.txt"], "encrypt_document", max_workers=17
+        )
+        self.assertFalse(result["success"])
+        self.assertIn("1到16", result["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_encryption_security.py
+++ b/tests/test_encryption_security.py
@@ -1,0 +1,43 @@
+import base64
+import hashlib
+import unittest
+
+from cryptography.fernet import Fernet, InvalidToken
+
+import general_server
+
+
+class EncryptionSecurityTests(unittest.TestCase):
+    def test_encryption_uses_versioned_randomized_container(self):
+        first = general_server._encrypt_payload(b"confidential", "correct horse")
+        second = general_server._encrypt_payload(b"confidential", "correct horse")
+
+        self.assertTrue(first.startswith(general_server.ENCRYPTION_MAGIC))
+        self.assertNotEqual(first, second)
+        plaintext, legacy = general_server._decrypt_payload(first, "correct horse")
+        self.assertEqual(plaintext, b"confidential")
+        self.assertFalse(legacy)
+
+    def test_wrong_password_is_rejected(self):
+        encrypted = general_server._encrypt_payload(b"confidential", "right")
+        with self.assertRaises(InvalidToken):
+            general_server._decrypt_payload(encrypted, "wrong")
+
+    def test_legacy_payload_remains_readable(self):
+        password = "legacy-password"
+        legacy_key = base64.urlsafe_b64encode(
+            hashlib.sha256(password.encode("utf-8")).digest()
+        )
+        legacy_payload = Fernet(legacy_key).encrypt(b"legacy data")
+
+        plaintext, legacy = general_server._decrypt_payload(legacy_payload, password)
+        self.assertEqual(plaintext, b"legacy data")
+        self.assertTrue(legacy)
+
+    def test_empty_password_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "密码不能为空"):
+            general_server._encrypt_payload(b"data", "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stdio_cleanliness.py
+++ b/tests/test_stdio_cleanliness.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+import unittest
+
+
+class StdioCleanlinessTests(unittest.TestCase):
+    def test_server_imports_do_not_write_to_stdout(self):
+        for module in (
+            "word_server",
+            "excel_server",
+            "powerpoint_server",
+            "general_server",
+        ):
+            with self.subTest(module=module):
+                process = subprocess.run(
+                    [sys.executable, "-c", f"import {module}"],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(process.returncode, 0, process.stderr)
+                self.assertEqual(process.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/word_server.py
+++ b/word_server.py
@@ -25,8 +25,8 @@ try:
     from docx.oxml import OxmlElement
     import docx.opc.constants
 except ImportError:
-    print("警告: 未检测到python-docx库，Word文档功能将不可用")
-    print("请使用以下命令安装: pip install python-docx")
+    print("警告: 未检测到python-docx库，Word文档功能将不可用", file=sys.stderr)
+    print("请使用以下命令安装: pip install python-docx", file=sys.stderr)
     docx_installed = False
 
 # 尝试导入Pillow库，用于图片处理
@@ -34,8 +34,8 @@ pillow_installed = True
 try:
     from PIL import Image
 except ImportError:
-    print("警告: 未检测到Pillow库，图片处理功能将受限")
-    print("请使用以下命令安装: pip install Pillow")
+    print("警告: 未检测到Pillow库，图片处理功能将受限", file=sys.stderr)
+    print("请使用以下命令安装: pip install Pillow", file=sys.stderr)
     pillow_installed = False
 
 # 创建一个MCP服务器，保持名称与配置文件一致
@@ -447,7 +447,8 @@ def set_paragraph_spacing(
     # 打印接收到的参数，用于调试
     print(f"接收到的参数: file_path={file_path}, paragraph_index={paragraph_index}, "
           f"before_spacing={before_spacing}, after_spacing={after_spacing}, "
-          f"line_spacing={line_spacing}, line_spacing_rule={line_spacing_rule}")
+          f"line_spacing={line_spacing}, line_spacing_rule={line_spacing_rule}",
+          file=sys.stderr)
     
     # 检查参数是否为None
     if paragraph_index is None:
@@ -1834,5 +1835,5 @@ def merge_documents(
 
 if __name__ == "__main__":
     # 运行MCP服务器
-    print("启动OFFICE EDITOR服务器...")
-    mcp.run() 
+    print("启动OFFICE EDITOR服务器...", file=sys.stderr)
+    mcp.run()


### PR DESCRIPTION
## Summary

- enforce `OFFICE_EDIT_PATH` boundaries across general document, OCR, translation, encryption, database export/import, and batch helpers
- replace deterministic SHA-256 password derivation with a versioned, randomly salted Scrypt + Fernet container while retaining legacy decrypt compatibility
- keep MCP stdio clean by routing startup, dependency, debug, and shutdown messages to stderr
- isolate optional imports so one missing package no longer disables unrelated general-server capabilities
- cap batch requests at 100 files and 16 workers, and fix batch parameter routing for database export and general file operations

## Why

The remaining high-priority issues could allow general tools to read or write outside the configured workspace, exposed encrypted files to cheap offline password guessing, polluted MCP's stdout transport, and allowed unbounded batch concurrency. A single missing optional dependency could also disable otherwise available features.

## Compatibility and impact

- existing legacy encrypted files remain readable
- decrypting a legacy file returns a recommendation to re-encrypt it
- empty encryption passwords are now rejected
- oversized batch requests fail early with a clear error
- no files were deleted

## Validation

- `python -m unittest discover -s tests -v` — 14 tests passed
- `python -m compileall -q .`
- AST parse of all top-level Python entrypoints
- JSON parse of `.cursor/mcp.json`
- `git diff --check`
- subprocess import checks confirm all four MCP server modules write no stdout
